### PR TITLE
🔨 fix: 로그인 시 멤버의 추가정보 조회 불일치 에러 해결

### DIFF
--- a/src/main/java/fouragrant/scentasy/biz/member/service/AuthService.java
+++ b/src/main/java/fouragrant/scentasy/biz/member/service/AuthService.java
@@ -72,7 +72,7 @@ public class AuthService {
             tokenDto.setMemberId(member.getId());  // MemberId 설정
             tokenDto.setImageUrl(member.getImageUrl());  // Migurl 설정
 
-            ExtraInfo extraInfo = extraInfoRepository.findById(member.getId())
+            ExtraInfo extraInfo = extraInfoRepository.findById(member.getExtraInfo().getId())
                     .orElseThrow(() -> new CommonException(ErrorCode.EXTRA_INFO_NOT_FOUND)); // 적절한 에러 코드 사용
             tokenDto.setNickname(extraInfo.getNickname());
 


### PR DESCRIPTION
# ⛓️ Related Issues
관련 이슈
- #28 

## ☁️ what to do 
작업 내용에 대한 요약을 적어주세요.
- 로그인 시 가입할때 작성했던 닉네임과 다른 닉네임이 조회됩니다.

## 💫 Changes in the project
주요 변경 사항이나 추가된 기능에 대해 설명해주세요.
- 로그인 시 멤버의 추가정보id로 정보를 얻어오는 것이 아닌 멤버 id로 얻어오고 있어서 추가정보 id로 얻어오도록 수정했습니다.
- 로그인 시 멤버의 추가정보 id로 추가정보를 조회합니다.
