### PR TITLE
🔨 Fix: #35 향수 관련 토큰 인증 설정

### DIFF
--- a/src/main/java/fouragrant/scentasy/biz/member/service/CustomUserDetailsService.java
+++ b/src/main/java/fouragrant/scentasy/biz/member/service/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package fouragrant.scentasy.biz.member.service;
 
+import fouragrant.scentasy.biz.member.CustomUserDetails;
 import fouragrant.scentasy.biz.member.domain.Member;
 import fouragrant.scentasy.biz.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,19 +22,19 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    @Transactional
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return memberRepository.findByEmail(username)
-                .map(this::createUserDetails)
-                .orElseThrow(() -> new UsernameNotFoundException(username + " -> 데이터베이스에서 찾을 수 없습니다."));
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 가진 회원이 존재하지 않습니다: " + email));
+
+        return createUserDetails(member);
     }
 
     // DB 에 User 값이 존재한다면 UserDetails 객체로 만들어서 리턴
     private UserDetails createUserDetails(Member member) {
         GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(member.getAuthority().toString());
 
-        return new User(
-                //String.valueOf(member.getId()),
+        return new CustomUserDetails(
+                member.getId(),
                 member.getEmail(),
                 member.getPassword(),
                 Collections.singleton(grantedAuthority)

--- a/src/main/java/fouragrant/scentasy/biz/perfume/controller/PerfumeController.java
+++ b/src/main/java/fouragrant/scentasy/biz/perfume/controller/PerfumeController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -45,11 +46,9 @@ public class PerfumeController {
                     schema = @Schema(implementation = PerfumeDto.class)
             )
     )
-    @PostMapping("/save/{memberId}")
-    public ResponseEntity<?> createPerfume(@PathVariable("memberId") Long memberId, @RequestBody PerfumeDto perfumeDto) {
-        Member member = memberService.findById(memberId);
+    @PostMapping
+    public ResponseEntity<?> createPerfume(@RequestBody PerfumeDto perfumeDto, @AuthenticationPrincipal Member member) {
         perfumeService.createPerfume(perfumeDto, member);
-
         return ResponseEntity.ok(Response.createSuccess("0000", perfumeDto));
     }
 
@@ -65,7 +64,7 @@ public class PerfumeController {
                     schema = @Schema(implementation = PerfumeDto.class)
             )
     )
-    @GetMapping("/detail/{perfumeId}")
+    @GetMapping("/{perfumeId}")
     public ResponseEntity<?> getPerfume(@PathVariable Long perfumeId) {
         Perfume perfume = perfumeService.findPerfumeById(perfumeId);
         PerfumeDto perfumeDto = PerfumeDto.fromEntity(perfume);
@@ -85,10 +84,9 @@ public class PerfumeController {
                     schema = @Schema(implementation = Perfume.class)
             )
     )
-    @GetMapping("/list/{memberId}")
-    public ResponseEntity<?> getMemberPerfume(@PathVariable Long memberId) {
-        List<Perfume> perfumes = perfumeService.findPerfumesByMemberId(memberId);
-
+    @GetMapping
+    public ResponseEntity<?> getMemberPerfume(@AuthenticationPrincipal Member member) {
+        List<Perfume> perfumes = perfumeService.findPerfumesByMemberId(member);
         return ResponseEntity.ok(Response.createSuccess("0000", perfumes));
     }
 
@@ -104,9 +102,9 @@ public class PerfumeController {
                     schema = @Schema(implementation = Integer.class)
             )
     )
-    @GetMapping("/count/{memberId}")
-    public ResponseEntity<?> getMemberPerfumeCount(@PathVariable Long memberId) {
-        int perfumeCount = perfumeService.countPerfumesByMemberId(memberId);
+    @GetMapping("/count")
+    public ResponseEntity<?> getMemberPerfumeCount(@AuthenticationPrincipal Member member) {
+        int perfumeCount = perfumeService.countPerfumesByMemberId(member);
         return ResponseEntity.ok(Response.createSuccess("0000", perfumeCount));
     }
 

--- a/src/main/java/fouragrant/scentasy/biz/perfume/controller/PerfumeController.java
+++ b/src/main/java/fouragrant/scentasy/biz/perfume/controller/PerfumeController.java
@@ -47,8 +47,8 @@ public class PerfumeController {
             )
     )
     @PostMapping
-    public ResponseEntity<?> createPerfume(@RequestBody PerfumeDto perfumeDto, @AuthenticationPrincipal Member member) {
-        perfumeService.createPerfume(perfumeDto, member);
+    public ResponseEntity<?> savePerfume(@RequestBody PerfumeDto perfumeDto, @AuthenticationPrincipal Member member) {
+        perfumeService.savePerfume(perfumeDto, member);
         return ResponseEntity.ok(Response.createSuccess("0000", perfumeDto));
     }
 
@@ -65,7 +65,7 @@ public class PerfumeController {
             )
     )
     @GetMapping("/{perfumeId}")
-    public ResponseEntity<?> getPerfume(@PathVariable Long perfumeId) {
+    public ResponseEntity<?> getPerfumeDetails(@PathVariable Long perfumeId) {
         Perfume perfume = perfumeService.findPerfumeById(perfumeId);
         PerfumeDto perfumeDto = PerfumeDto.fromEntity(perfume);
 
@@ -85,8 +85,8 @@ public class PerfumeController {
             )
     )
     @GetMapping
-    public ResponseEntity<?> getMemberPerfume(@AuthenticationPrincipal Member member) {
-        List<Perfume> perfumes = perfumeService.findPerfumesByMemberId(member);
+    public ResponseEntity<?> getMemberPerfumes(@AuthenticationPrincipal Member member) {
+        List<Perfume> perfumes = perfumeService.getMemberPerfumes(member);
         return ResponseEntity.ok(Response.createSuccess("0000", perfumes));
     }
 
@@ -104,7 +104,7 @@ public class PerfumeController {
     )
     @GetMapping("/count")
     public ResponseEntity<?> getMemberPerfumeCount(@AuthenticationPrincipal Member member) {
-        int perfumeCount = perfumeService.countPerfumesByMemberId(member);
+        int perfumeCount = perfumeService.getMemberPerfumeCount(member);
         return ResponseEntity.ok(Response.createSuccess("0000", perfumeCount));
     }
 

--- a/src/main/java/fouragrant/scentasy/biz/perfume/controller/PerfumeController.java
+++ b/src/main/java/fouragrant/scentasy/biz/perfume/controller/PerfumeController.java
@@ -1,8 +1,6 @@
 package fouragrant.scentasy.biz.perfume.controller;
 
-import fouragrant.scentasy.biz.member.domain.Member;
-import fouragrant.scentasy.biz.member.dto.ExtraInfoReqDto;
-import fouragrant.scentasy.biz.member.dto.ExtraInfoResDto;
+import fouragrant.scentasy.biz.member.CustomUserDetails;
 import fouragrant.scentasy.biz.member.service.MemberService;
 import fouragrant.scentasy.biz.perfume.domain.Perfume;
 import fouragrant.scentasy.biz.perfume.dto.PerfumeDto;
@@ -47,8 +45,10 @@ public class PerfumeController {
             )
     )
     @PostMapping
-    public ResponseEntity<?> savePerfume(@RequestBody PerfumeDto perfumeDto, @AuthenticationPrincipal Member member) {
-        perfumeService.savePerfume(perfumeDto, member);
+    public ResponseEntity<?> savePerfume(@RequestBody PerfumeDto perfumeDto, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMemberId();
+        perfumeService.savePerfume(perfumeDto, memberId);
+
         return ResponseEntity.ok(Response.createSuccess("0000", perfumeDto));
     }
 
@@ -85,8 +85,10 @@ public class PerfumeController {
             )
     )
     @GetMapping
-    public ResponseEntity<?> getMemberPerfumes(@AuthenticationPrincipal Member member) {
-        List<Perfume> perfumes = perfumeService.getMemberPerfumes(member);
+    public ResponseEntity<?> getMemberPerfumes(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMemberId();
+        List<Perfume> perfumes = perfumeService.getMemberPerfumes(memberId);
+
         return ResponseEntity.ok(Response.createSuccess("0000", perfumes));
     }
 
@@ -103,8 +105,10 @@ public class PerfumeController {
             )
     )
     @GetMapping("/count")
-    public ResponseEntity<?> getMemberPerfumeCount(@AuthenticationPrincipal Member member) {
-        int perfumeCount = perfumeService.getMemberPerfumeCount(member);
+    public ResponseEntity<?> getMemberPerfumeCount(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMemberId();
+        int perfumeCount = perfumeService.getMemberPerfumeCount(memberId);
+
         return ResponseEntity.ok(Response.createSuccess("0000", perfumeCount));
     }
 

--- a/src/main/java/fouragrant/scentasy/biz/perfume/service/PerfumeService.java
+++ b/src/main/java/fouragrant/scentasy/biz/perfume/service/PerfumeService.java
@@ -2,13 +2,9 @@ package fouragrant.scentasy.biz.perfume.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import fouragrant.scentasy.biz.chat.dto.ChatReqDto;
 import fouragrant.scentasy.biz.member.domain.Member;
-import fouragrant.scentasy.biz.member.domain.Scent;
-import fouragrant.scentasy.biz.member.service.MemberService;
 import fouragrant.scentasy.biz.perfume.domain.Perfume;
 import fouragrant.scentasy.biz.perfume.dto.PerfumeDto;
-import fouragrant.scentasy.biz.perfume.dto.PerfumeNotesDto;
 import fouragrant.scentasy.biz.perfume.repository.PerfumeRepository;
 import fouragrant.scentasy.common.exception.CommonException;
 import fouragrant.scentasy.common.exception.ErrorCode;
@@ -29,11 +25,13 @@ import static fouragrant.scentasy.biz.member.domain.Scent.SCENT_MAPPING;
 @Slf4j
 public class PerfumeService {
     private final PerfumeRepository perfumeRepository;
+
     @Value("${flask.url}") // flask.url 프로퍼티를 주입
     private String flaskUrl; // 필드 추가
 
     // 생성된 향수 저장
     public Perfume createPerfume(PerfumeDto perfumeDto, Member member) {
+        validateMember(member);
         Perfume perfume = PerfumeDto.fromDto(perfumeDto, member);
 
         return perfumeRepository.save(perfume);
@@ -45,20 +43,30 @@ public class PerfumeService {
                 .orElseThrow(() -> new CommonException(ErrorCode.PERFUME_NOT_FOUND));
     }
 
-    // 멤버 ID로 향수 전체 목록 조회
-    public List<Perfume> findPerfumesByMemberId(Long memberId) {
-         List<Perfume> perfumes = perfumeRepository.findByMemberId(memberId);
+    // 멤버 향수 전체 목록 조회
+    public List<Perfume> findPerfumesByMemberId(Member member) {
+        validateMember(member);
+        List<Perfume> perfumes = perfumeRepository.findByMemberId(member.getId());
 
-         if (perfumes.isEmpty()) {
-             throw new CommonException(ErrorCode.PERFUME_NOT_FOUND);
-         }
+        if (perfumes.isEmpty()) {
+            throw new CommonException(ErrorCode.PERFUME_NOT_FOUND);
+        }
 
-         return perfumes;
+        return perfumes;
     }
 
     // 멤버 ID로 향수 전체 개수 조회
-    public int countPerfumesByMemberId(Long memberId) {
-        return perfumeRepository.countByMemberId(memberId);
+    public int countPerfumesByMemberId(Member member) {
+        validateMember(member);
+
+        return perfumeRepository.countByMemberId(member.getId());
+    }
+
+    // 멤버 검증
+    private void validateMember(Member member) {
+        if (member == null) {
+            throw new CommonException(ErrorCode.MEMBER_NOT_FOUND);
+        }
     }
 
     public List<String> notesToString() {

--- a/src/main/java/fouragrant/scentasy/biz/perfume/service/PerfumeService.java
+++ b/src/main/java/fouragrant/scentasy/biz/perfume/service/PerfumeService.java
@@ -30,7 +30,7 @@ public class PerfumeService {
     private String flaskUrl; // 필드 추가
 
     // 생성된 향수 저장
-    public Perfume createPerfume(PerfumeDto perfumeDto, Member member) {
+    public Perfume savePerfume(PerfumeDto perfumeDto, Member member) {
         validateMember(member);
         Perfume perfume = PerfumeDto.fromDto(perfumeDto, member);
 
@@ -44,7 +44,7 @@ public class PerfumeService {
     }
 
     // 멤버 향수 전체 목록 조회
-    public List<Perfume> findPerfumesByMemberId(Member member) {
+    public List<Perfume> getMemberPerfumes(Member member) {
         validateMember(member);
         List<Perfume> perfumes = perfumeRepository.findByMemberId(member.getId());
 
@@ -55,8 +55,8 @@ public class PerfumeService {
         return perfumes;
     }
 
-    // 멤버 ID로 향수 전체 개수 조회
-    public int countPerfumesByMemberId(Member member) {
+    // 멤버 향수 전체 개수 조회
+    public int getMemberPerfumeCount(Member member) {
         validateMember(member);
 
         return perfumeRepository.countByMemberId(member.getId());

--- a/src/main/java/fouragrant/scentasy/biz/perfume/service/PerfumeService.java
+++ b/src/main/java/fouragrant/scentasy/biz/perfume/service/PerfumeService.java
@@ -2,7 +2,9 @@ package fouragrant.scentasy.biz.perfume.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fouragrant.scentasy.biz.member.CustomUserDetails;
 import fouragrant.scentasy.biz.member.domain.Member;
+import fouragrant.scentasy.biz.member.service.MemberService;
 import fouragrant.scentasy.biz.perfume.domain.Perfume;
 import fouragrant.scentasy.biz.perfume.dto.PerfumeDto;
 import fouragrant.scentasy.biz.perfume.repository.PerfumeRepository;
@@ -25,13 +27,14 @@ import static fouragrant.scentasy.biz.member.domain.Scent.SCENT_MAPPING;
 @Slf4j
 public class PerfumeService {
     private final PerfumeRepository perfumeRepository;
+    private final MemberService memberService;
 
     @Value("${flask.url}") // flask.url 프로퍼티를 주입
     private String flaskUrl; // 필드 추가
 
     // 생성된 향수 저장
-    public Perfume savePerfume(PerfumeDto perfumeDto, Member member) {
-        validateMember(member);
+    public Perfume savePerfume(PerfumeDto perfumeDto, Long memberId) {
+        Member member = memberService.findById(memberId);
         Perfume perfume = PerfumeDto.fromDto(perfumeDto, member);
 
         return perfumeRepository.save(perfume);
@@ -44,9 +47,8 @@ public class PerfumeService {
     }
 
     // 멤버 향수 전체 목록 조회
-    public List<Perfume> getMemberPerfumes(Member member) {
-        validateMember(member);
-        List<Perfume> perfumes = perfumeRepository.findByMemberId(member.getId());
+    public List<Perfume> getMemberPerfumes(Long memberId) {
+        List<Perfume> perfumes = perfumeRepository.findByMemberId(memberId);
 
         if (perfumes.isEmpty()) {
             throw new CommonException(ErrorCode.PERFUME_NOT_FOUND);
@@ -56,17 +58,8 @@ public class PerfumeService {
     }
 
     // 멤버 향수 전체 개수 조회
-    public int getMemberPerfumeCount(Member member) {
-        validateMember(member);
-
-        return perfumeRepository.countByMemberId(member.getId());
-    }
-
-    // 멤버 검증
-    private void validateMember(Member member) {
-        if (member == null) {
-            throw new CommonException(ErrorCode.MEMBER_NOT_FOUND);
-        }
+    public int getMemberPerfumeCount(Long memberId) {
+        return perfumeRepository.countByMemberId(memberId);
     }
 
     public List<String> notesToString() {

--- a/src/main/java/fouragrant/scentasy/config/SecurityConfig.java
+++ b/src/main/java/fouragrant/scentasy/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 // 로그인, 회원가입 API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
                 .and()
                 .authorizeHttpRequests()
-                    .requestMatchers("/auth/**", "/swagger-ui/**",  "/v3/api-docs/**", "/api/**").permitAll()
+                    .requestMatchers("/auth/**", "/swagger-ui/**",  "/v3/api-docs/**").permitAll()
                     .anyRequest().authenticated()   // 나머지 API 는 전부 인증 필요
 
                 // JwtFilter 를 addFilterBefore 로 등록했던 JwtSecurityConfig 클래스를 적용

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: dev
 
   output:
     ansi:


### PR DESCRIPTION
# ⛓️ Related Issues
관련 이슈
- #35 

## ☁️ what to do 
작업 내용에 대한 요약을 적어주세요.
- 향수 관련 인증 설정 및 리팩토링

## 💫 Changes in the project
주요 변경 사항이나 추가된 기능에 대해 설명해주세요.
- auth 및 문서 관련 API를 제외하고 인증이 필요하도록 수정했습니다.
- 향수 관련 API 경로에 멤버 아이디를 넣는 대신 토큰 인증으로 설정했습니다.
- 향수 관련 메소드명을 일관성 있게 수정했습니다.
- 토큰 인증 시 인증된 사용자를 null로 반환하는 오류를 해결했습니다.
